### PR TITLE
Add FreeBSD to releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,20 +1,16 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
-
 # The lines below are called `modelines`. See `:help modeline`
 # Feel free to remove those if you don't want/need to use them.
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
-
 version: 2
-
 before:
   hooks:
     # You may remove this if you don't use go modules.
     - go mod tidy
     # you may remove this if you don't need go generate
     - go generate ./...
-
 builds:
   - env:
       - CGO_ENABLED=0
@@ -22,45 +18,34 @@ builds:
       - linux
       - windows
       - darwin
+      - freebsd
     main: ./main.go
-
 archives:
-  - format: tar.gz
+  - formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
-      {{- if .Arm }}v{{ .Arm }}{{ end }}
+      {{ .ProjectName }}_ {{- title .Os }}_ {{- if eq .Arch "amd64" }}x86_64 {{- else if eq .Arch "386" }}i386 {{- else }}{{ .Arch }}{{ end }} {{- if .Arm }}v{{ .Arm }}{{ end }}
     # use zip for windows archives
     format_overrides:
       - goos: windows
-        format: zip
-
+        formats: ['zip']
 changelog:
   sort: asc
   filters:
     exclude:
       - "^docs:"
       - "^test:"
-
 release:
   footer: >-
-
     ---
 
     Released by [GoReleaser](https://github.com/goreleaser/goreleaser).
-
 brews:
   - caveats: "daylight is very new, so be sure to check for updates and report any bugs"
     description: "track sunrise / sunset times for your date and location"
     license: "unlicensed"
-
     test: |
       daylight --help
-
     repository:
       owner: jbreckmckye
       name: homebrew-formulae


### PR DESCRIPTION
goreleaser supports FreeBSD. Added it (and fixed a couple of deprecation warnings; you might like to check the homebrew notes too, I didn't fix that).

Tested released binaries on arm and amd64 FreeBSD 14 instances. Works a treat 😄 